### PR TITLE
workaround wheel compat issue on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.7","3.8","3.9","3.10", "3.11"]
+    env:
+      SYSTEM_VERSION_COMPAT: 0
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
as proposed [earlier](https://github.com/actions/setup-python/issues/469#issuecomment-1192522949), use this workaround if the compatible tags got somehow messed up on the macos runner.

If we merge this, we could do a new release that would solve the [CI failures](https://github.com/Simple-Robotics/proxsuite/actions/runs/4284782999/jobs/7462212688#step:9:345) we observe on a [PR](https://github.com/Simple-Robotics/proxsuite/pull/184) currently in proxsuite.

Also, we will finally be able to have pip wheels for windows thanks to https://github.com/cmake-wheel/cmeel/commit/484e1ca18c2347e92101ce2988d553acca79acd8.