### PR TITLE
relax tomli constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Topic :: System :: Software Distribution",
 ]
 dependencies = [
-  "tomli>=2.2.1 ; python_full_version < '3.11'",
+  "tomli>=2.1.0 ; python_full_version < '3.11'",
 ]
 description = "Create Wheel from CMake projects"
 license = "BSD-2-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ requires-dist = [
     { name = "cmake", marker = "extra == 'build'", specifier = ">=3.31.2" },
     { name = "git-archive-all", marker = "extra == 'build'", git = "https://github.com/nim65s/git-archive-all" },
     { name = "packaging", marker = "extra == 'build'", specifier = ">=24.2" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.2.1" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.1.0" },
     { name = "wheel", marker = "extra == 'build'", specifier = ">=0.45.1" },
 ]
 


### PR DESCRIPTION
No idea why, but cibuildwheel trying to install
"cmeel[build] @ git+https://github.com/cmake-wheel/cmeel.git" on macos arm64 cp310 fails with:

        The conflict is caused by:
            cmeel 0.53.3 depends on tomli>=2.2.1; python_full_version < "3.11"
            The user requested (constraint) tomli==2.1.0