### PR TITLE
Fix symlink issue in sdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix symlink issue in sdist
+
 ## [v0.57.1] - 2025-02-05
 
 - Install license file in `*.dist-info/license{ -> s}/`

--- a/cmeel/sdist.py
+++ b/cmeel/sdist.py
@@ -52,7 +52,7 @@ def sdist_impl(sdist_directory) -> str:
         LOG.info("create final archive with previous one + PKG-INFO")
         with tarfile.open(tmp_tar, "r") as tr, tarfile.open(def_tar, "w:gz") as tw:
             for member in tr.getmembers():
-                tw.addfile(member, tr.extractfile(member.name))
+                tw.addfile(member, tr.extractfile(member))
             tw.add(str(tmp_pkg), f"{distribution}/PKG-INFO")
 
     return distribution


### PR DESCRIPTION
eg.
```python
KeyError: "linkname 'example_robot_data-4.2.0/cmake/_unittests/..' not found"