### PR TITLE
back to metadata version 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- back to metadata version 2.4
+
 ## [v0.60.0] - 2026-05-09
 
 - :warning: Refactored python API. No change to cli or pip APIs.

--- a/cmeel/metadata.py
+++ b/cmeel/metadata.py
@@ -54,11 +54,11 @@ class Metadata:
     def gen(self) -> str:
         """Generate full file content."""
         self.data = [
-            "Metadata-Version: 2.5",
+            "Metadata-Version: 2.4",  # TODO actually we are 2.5, but PyPI refuse that for now
             f"Name: {self.conf['name']}",
             f"Version: {self.conf['version']}",
             f"Summary: {self.conf['description']}",
-            f"Requires-Python: {self.conf.get('requires-python', '>=3.8')}",
+            f"Requires-Python: {self.conf.get('requires-python', '>=3.9')}",
         ]
 
         self.gen_license()


### PR DESCRIPTION
workaround on 2026-05-11:
```
Status: Downloaded newer image for ghcr.io/pypa/gh-action-pypi-publish:release-v1
Checking dist/libproxsuite-0.7.3-0-py3-none-macosx_10_9_x86_64.whl: ERROR    InvalidDistribution: Invalid distribution metadata: '2.5' is not a
         valid metadata version
```